### PR TITLE
chore: publish API docs to GitHub Pages via amp-catalog

### DIFF
--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -1,0 +1,20 @@
+name: Publish API docs
+
+# Publishes this API's Swagger UI to https://hmcts.github.io/api-cp-crime-caseingestion-prosecutor/ on release.
+# All the work lives in the shared catalog workflow; this repo only declares
+# where its OpenAPI spec is. See https://github.com/hmcts/amp-catalog.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    uses: hmcts/amp-catalog/.github/workflows/publish-swagger-ui.yml@v1
+    with:
+      openapi_path: src/main/resources/openapi/openapi.yml

--- a/src/main/resources/openapi/openapi.yml
+++ b/src/main/resources/openapi/openapi.yml
@@ -1,7 +1,11 @@
 openapi: 3.0.2
 servers:
-  - description: APIHub API Auto Mocking CPPI API
-    url: https://virtserver.swaggerhub.com/HMCTS-DTS/api-cp-crime-caseingestion-prosecutor/0.0.0
+  - description: API Common Platform Prosecutor Interface
+    url: https://api-cp-crime-caseingestion-prosecutor.net/{version}
+    variables:
+      version:
+        default: 0.0.0
+        description: API version; matches the spec info.version
 info:
   title: API Common Platform Prosecutor Interface
   description: Crime API providing information on Common Platform Prosecutor Interface (CPPI)


### PR DESCRIPTION
Adds the publish-api-docs.yml caller workflow so the spec is deployed to https://hmcts.github.io/api-cp-crime-caseingestion-prosecutor/ on release. Also fixes the servers block to replace the deprecated SwaggerHub virtserver URL with the standard HMCTS pattern.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
